### PR TITLE
mkdir cannot connect non 22 port

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ chmod 600 $TEMP_SSH_PRIVATE_KEY_FILE
 
 echo 'ssh start'
 # create directory if needed
-ssh -o StrictHostKeyChecking=no -i $TEMP_SSH_PRIVATE_KEY_FILE $1@$2 mkdir -p $5
+ssh -o StrictHostKeyChecking=no -p $3 -i $TEMP_SSH_PRIVATE_KEY_FILE $1@$2 mkdir -p $5
 
 echo 'sftp start'
 # create a temporary file containing sftp commands


### PR DESCRIPTION
由于未指定 -p，当ssh端口非22的时候无法连接